### PR TITLE
use libgcrypt20 on jessie

### DIFF
--- a/manifests/setup/settings.pp
+++ b/manifests/setup/settings.pp
@@ -48,7 +48,10 @@ class collectd::setup::settings {
         /Debian6/ => ['libmysqlclient16'],
         default   => ['libmysqlclient18'],
       },
-      'network'         => ['libgcrypt11'],
+      'network'         =>  "${::operatingsystem}${::operatingsystemmajrelease}" ? {
+        /Debian8/      => ['libgcrypt20'],
+        default        => ['libgcrypt11'],
+      },
       'netlink'         => ['libmnl0'],
       'nginx'           => ['libcurl3-gnutls'],
       'notify_desktop'  => ['libgdk-pixbuf2.0-0', 'libglib2.0-0', 'libnotify4'],


### PR DESCRIPTION
libgcrypt11 is not available anymore on debian8