### PR TITLE
Fix collectd_version fact

### DIFF
--- a/lib/facter/collectd_version.rb
+++ b/lib/facter/collectd_version.rb
@@ -1,7 +1,7 @@
 Facter.add("collectd_version") do
   setcode do
     output = %x{collectd -h 2>&1}
-    if $?.exitstatus and output.match(/collectd (\d+\.\d+\.\d+)[0-9a-h\.]*,/)
+    if $?.exitstatus and output.match(/collectd (\d+\.\d+\.\d+)[0-9a-z\.]*,/)
       $1
     else
       "0.0.0"


### PR DESCRIPTION
In "5.7.0.git,", "git" doesn't match /[0-9a-h\.]*/