### PR TITLE
feature/quickfix debian8 libmnl0 dependency

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -38,6 +38,10 @@ class collectd::package(
         package { 'libcollectdclient': ensure => $version }
       }
       if ($::osfamily == 'Debian') {
+	package { 'libmnl0': 
+	  ensure => 'present',
+	  before => Package['collectd','collectd-core'],
+	}
         package { 'libcollectdclient1': ensure => $version }
       }
     }


### PR DESCRIPTION
Force libmnl0 installation. 
This is a monkey-patching for fixing debian's 8 package. 

