### PR TITLE
Do not pass ensure to concat::fragment

### DIFF
--- a/manifests/config/chain.pp
+++ b/manifests/config/chain.pp
@@ -85,7 +85,6 @@ define collectd::config::chain (
     )
 
     concat::fragment { "${type}-${name}":
-      ensure  => $ensure,
       target  => $target,
       notify  => Service['collectd'],
       content => inline_template('


### PR DESCRIPTION
This parameter is deprecated in recent version of the concat module.