### PR TITLE
use version for plugin dependency resolution

### DIFF
--- a/manifests/setup/loadplugin.pp
+++ b/manifests/setup/loadplugin.pp
@@ -73,9 +73,15 @@ define collectd::setup::loadplugin($interval='default') {
 
   if ($plugindeps[$name]) {
     $pkgs = $plugindeps[$name]
+    # As apt is more strict on versioning , we have to force the version on
+    # Red Hat
+    $pluginversion =  $::osfamily ? {
+      'RedHat' => $::collectd::version,
+      default  => 'present',
+    }
     $dep_ensure = $::collectd::version ? {
       'absent' => 'absent',
-      default  => 'present',
+      default  => $pluginversion,
     }
     ensure_packages(
       $pkgs,


### PR DESCRIPTION
Plugins are versionned and should match with collectd installation