### PR TITLE
Require collectd::package::core in confdir

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -91,6 +91,7 @@ class collectd::config (
     force        => true,
     recurse      => true,
     recurselimit => 1,
+    require      => Class['::collectd::package::core'],
   }
 
   file { "${confdir}/collectd.conf.d":

--- a/spec/classes/collectd_config_spec.rb
+++ b/spec/classes/collectd_config_spec.rb
@@ -9,8 +9,10 @@ describe 'collectd::config' do
   }
 
   let(:pre_condition) {
+    '# Required for $confdir
+    include ::collectd::package
     # Required for collectd::override
-    'include ::collectd::service'
+    include ::collectd::service'
   }
 
   on_supported_os.each do |os, facts|


### PR DESCRIPTION
This ensures the package gets managed before confdir